### PR TITLE
Make site look like banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,49 @@
     />
     <meta name="theme-color" content="#000000" />
     <title>ScPL</title>
+    
+    <style>
+      body {
+        background-color: black;
+        color: white;
+      }
+
+      table {
+        margin-bottom: -12px;
+      }
+
+      #abbrev {
+        font-size: 100px;
+        font-weight: 700;
+      }
+
+      #subtitle {
+        color: #aaa;
+        word-wrap: break-word;
+        word-spacing: 100vw;
+        margin-top: -25px;
+      }
+
+      #links {
+        list-style-type: none;
+        padding: 0;
+      }
+
+      #links > li {
+        float: left;
+        padding: 5px;
+        margin: 4px;
+        background-color: #4e42f4;
+        border-radius: 5px;
+        min-width: 50px;
+        text-align: center;
+      }
+
+      #links > li > a {
+        color: white;
+        text-decoration: none;
+      }
+    </style>
   </head>
   <body>
   

--- a/index.html
+++ b/index.html
@@ -15,28 +15,24 @@
         background-color: black;
         color: white;
       }
-
-      table {
-        margin-bottom: -12px;
+      #header {
+        display: flex;
+        padding: 10px 0px;
       }
-
       #abbrev {
         font-size: 100px;
         font-weight: 700;
+        line-height: 80px;
       }
-
       #subtitle {
         color: #aaa;
         word-wrap: break-word;
         word-spacing: 100vw;
-        margin-top: -25px;
       }
-
       #links {
         list-style-type: none;
         padding: 0;
       }
-
       #links > li {
         float: left;
         padding: 5px;
@@ -46,7 +42,6 @@
         min-width: 50px;
         text-align: center;
       }
-
       #links > li > a {
         color: white;
         text-decoration: none;
@@ -55,12 +50,14 @@
   </head>
   <body>
   
-  <table>
-    <tr>
-      <td><span id="abbrev">ScPL</span></td>
-      <td><div id="subtitle">Shortcuts Programming Language</div></td>
-    </tr>
-  </table>
+  <div id="header">
+      <div>
+        <span id="abbrev">ScPL</span>
+      </div>
+      <div>
+        <div id="subtitle">Shortcuts Programming Language</div>
+      </div>
+  </div>
   
   <ul id="links">
     <li><a href="https://editor.scpl.dev">Editor</a></li>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,14 @@
   </head>
   <body>
   
-  <ul>
+  <table>
+    <tr>
+      <td><span id="abbrev">ScPL</span></td>
+      <td><div id="subtitle">Shortcuts Programming Language</div></td>
+    </tr>
+  </table>
+  
+  <ul id="links">
     <li><a href="https://editor.scpl.dev">Editor</a></li>
     <li><a href="https://docs.scpl.dev">Documentation</a></li>
   </ul>


### PR DESCRIPTION
This pull request makes the site look like the banner:

![ScPL banner by ROP#2788](https://user-images.githubusercontent.com/24855774/54282830-2ffa5000-4573-11e9-9172-36ad5346b3ae.png)

Compare to:

![Site as changed by this pull request](https://user-images.githubusercontent.com/24855774/54282922-646e0c00-4573-11e9-8df9-56d32e6b548b.png)

A few things are still in progress:

- [ ] Use the same font used in the banner
- [x] Don't use a table for layout
- [ ] Ensure colors match the banner
- [ ] Ensure compatibility with browsers other than Chromium (Firefox, WebKit)
- [ ] Add a footer in the bottom-right corner